### PR TITLE
support TLS and caller-supplied clients for the datastream Redis cache

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -33,6 +33,7 @@ client/schematic_client.go
 client/schematic_client_test.go
 client/logger_config_test.go
 datastream/cache.go
+datastream/cache_test.go
 datastream/client.go
 datastream/resource_cache.go
 datastream/client_test.go

--- a/.fernignore
+++ b/.fernignore
@@ -34,6 +34,7 @@ client/schematic_client_test.go
 client/logger_config_test.go
 datastream/cache.go
 datastream/cache_test.go
+datastream/cache_tls_test.go
 datastream/client.go
 datastream/resource_cache.go
 datastream/client_test.go

--- a/README.md
+++ b/README.md
@@ -579,6 +579,10 @@ options := &schematicoption.DatastreamOptions{
 }
 ```
 
+`Addr` also accepts a connection URL — `redis://host:6379` or `rediss://host:6380`
+for TLS — in which case any credentials, database index or TLS implied by the URL
+are used unless the config sets them explicitly.
+
 #### 2. Redis Cluster
 
 To use a Redis cluster, create a `RedisCacheClusterConfig` and pass it to the `DatastreamOptions`.
@@ -598,6 +602,38 @@ options := &schematicoption.DatastreamOptions{
 		RouteByLatency:   true,            // Route requests to the node with the lowest latency
 		RouteRandomly:    false,           // Disable random routing
 	},
+}
+```
+
+#### 3. TLS
+
+Both configs take a `TLSConfig`. Leave it nil for a plaintext connection. Against a
+server with a publicly-trusted certificate — AWS ElastiCache with encryption in
+transit, for example — an otherwise-empty `tls.Config` is enough, and hostname
+verification stays on:
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheConfig: &schematicoption.RedisCacheClusterConfig{
+		Addrs:     []string{"clustercfg.my-cache.abc123.use1.cache.amazonaws.com:6379"},
+		Username:  "schematic",
+		Password:  os.Getenv("REDIS_PASSWORD"),
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	},
+}
+```
+
+#### 4. Bringing your own client
+
+If your application already constructs a Redis client — with its own TLS, pool
+sizing and timeouts — hand it to the datastream directly instead of restating
+every field. The SDK shares the client across all of its caches and does not
+close it; the caller owns its lifecycle.
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheTTL:    5 * time.Minute,
+	CacheConfig: schematicoption.WithRedisClient(myRedisClient), // any redis.UniversalClient
 }
 ```
 

--- a/core/custom_options.go
+++ b/core/custom_options.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"crypto/tls"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/schematichq/schematic-go/cache"
 	"github.com/schematichq/schematic-go/http"
 )
@@ -192,6 +194,11 @@ type RedisCacheConfig struct {
 	DisableIdentity       bool
 	IdentitySuffix        string
 	UnstableResp3         bool
+
+	// TLSConfig enables TLS for the connection. Leave nil for plaintext. An
+	// empty &tls.Config{} is enough for a server with a publicly-trusted
+	// certificate; hostname verification stays on.
+	TLSConfig *tls.Config
 }
 
 func (c RedisCacheConfig) applyDatastreamOptions(opts *DatastreamOptions) {
@@ -225,14 +232,38 @@ type RedisCacheClusterConfig struct {
 	DisableIdentity       bool
 	IdentitySuffix        string
 	UnstableResp3         bool
+
+	// TLSConfig enables TLS for the connection. Leave nil for plaintext. An
+	// empty &tls.Config{} is enough for a server with a publicly-trusted
+	// certificate; hostname verification stays on.
+	TLSConfig *tls.Config
 }
 
 func (c RedisCacheClusterConfig) applyDatastreamOptions(opts *DatastreamOptions) {
 	opts.CacheConfig = c
 }
 
+// RedisClientConfig hands the datastream an already-constructed Redis client
+// instead of describing one field by field. Use it when the caller already
+// builds a client — with its own TLS, pool sizing and timeouts — and wants the
+// SDK to share it rather than re-derive it.
+//
+// The SDK does not close the client; the caller owns its lifecycle.
+type RedisClientConfig struct {
+	Client redis.UniversalClient
+}
+
+func (c RedisClientConfig) applyDatastreamOptions(opts *DatastreamOptions) {
+	opts.CacheConfig = c
+}
+
 func WithRedisCache(opts CacheConfig) CacheConfig {
 	return opts
+}
+
+// WithRedisClient wraps an existing Redis client as a datastream cache config.
+func WithRedisClient(client redis.UniversalClient) CacheConfig {
+	return RedisClientConfig{Client: client}
 }
 
 type ClientOptUseDatastream struct {

--- a/datastream/cache.go
+++ b/datastream/cache.go
@@ -1,6 +1,8 @@
 package datastream
 
 import (
+	"strings"
+
 	"github.com/redis/go-redis/v9"
 	"github.com/schematichq/schematic-go/cache"
 	"github.com/schematichq/schematic-go/core"
@@ -81,6 +83,10 @@ func buildRedisClient(configOpt *core.DatastreamOptions) redis.UniversalClient {
 	case core.RedisCacheClusterConfig:
 		config := configOpt.CacheConfig.(core.RedisCacheClusterConfig)
 		return redis.NewClusterClient(ToRedisClusterOptions(&config))
+	case *core.RedisClientConfig:
+		return configOpt.CacheConfig.(*core.RedisClientConfig).Client
+	case core.RedisClientConfig:
+		return configOpt.CacheConfig.(core.RedisClientConfig).Client
 	}
 
 	return nil
@@ -121,7 +127,7 @@ func buildLocalCache(opt *core.DatastreamOptions) (CompanyCacheProvider, UserCac
 }
 
 func ToRedisOptions(config *core.RedisCacheConfig) *redis.Options {
-	return &redis.Options{
+	opts := &redis.Options{
 		Network:               config.Network,
 		Addr:                  config.Addr,
 		ClientName:            config.ClientName,
@@ -148,6 +154,44 @@ func ToRedisOptions(config *core.RedisCacheConfig) *redis.Options {
 		DisableIdentity:       config.DisableIdentity,
 		IdentitySuffix:        config.IdentitySuffix,
 		UnstableResp3:         config.UnstableResp3,
+		TLSConfig:             config.TLSConfig,
+	}
+
+	applyRedisURL(opts, config.Addr)
+
+	return opts
+}
+
+// applyRedisURL lets Addr be a connection URL ("redis://host:6379",
+// "rediss://host:6380") as well as the bare "host:port" go-redis expects.
+// Anything the URL carries that the config didn't set explicitly — credentials,
+// DB index, TLS for the rediss scheme — is filled in from it; explicit config
+// fields always win. A non-URL Addr is left untouched.
+func applyRedisURL(opts *redis.Options, addr string) {
+	if !strings.Contains(addr, "://") {
+		return
+	}
+
+	parsed, err := redis.ParseURL(addr)
+	if err != nil {
+		// Not something go-redis understands; leave Addr as given so the dial
+		// error names the address the caller actually configured.
+		return
+	}
+
+	opts.Addr = parsed.Addr
+	opts.Network = parsed.Network
+	if opts.Username == "" {
+		opts.Username = parsed.Username
+	}
+	if opts.Password == "" {
+		opts.Password = parsed.Password
+	}
+	if opts.DB == 0 {
+		opts.DB = parsed.DB
+	}
+	if opts.TLSConfig == nil {
+		opts.TLSConfig = parsed.TLSConfig
 	}
 }
 
@@ -179,5 +223,6 @@ func ToRedisClusterOptions(config *core.RedisCacheClusterConfig) *redis.ClusterO
 		DisableIdentity:       config.DisableIdentity,
 		IdentitySuffix:        config.IdentitySuffix,
 		UnstableResp3:         config.UnstableResp3,
+		TLSConfig:             config.TLSConfig,
 	}
 }

--- a/datastream/cache_test.go
+++ b/datastream/cache_test.go
@@ -1,0 +1,143 @@
+package datastream
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/schematichq/schematic-go/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToRedisOptionsTLSConfig(t *testing.T) {
+	t.Run("nil TLSConfig stays nil", func(t *testing.T) {
+		opts := ToRedisOptions(&core.RedisCacheConfig{Addr: "localhost:6379"})
+
+		assert.Nil(t, opts.TLSConfig)
+		assert.Equal(t, "localhost:6379", opts.Addr)
+	})
+
+	t.Run("TLSConfig is propagated", func(t *testing.T) {
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+		opts := ToRedisOptions(&core.RedisCacheConfig{Addr: "localhost:6379", TLSConfig: tlsConfig})
+
+		require.NotNil(t, opts.TLSConfig)
+		assert.Same(t, tlsConfig, opts.TLSConfig)
+		assert.Equal(t, uint16(tls.VersionTLS12), opts.TLSConfig.MinVersion)
+	})
+}
+
+func TestToRedisClusterOptionsTLSConfig(t *testing.T) {
+	t.Run("nil TLSConfig stays nil", func(t *testing.T) {
+		opts := ToRedisClusterOptions(&core.RedisCacheClusterConfig{Addrs: []string{"localhost:6379"}})
+
+		assert.Nil(t, opts.TLSConfig)
+	})
+
+	t.Run("TLSConfig is propagated", func(t *testing.T) {
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+		opts := ToRedisClusterOptions(&core.RedisCacheClusterConfig{
+			Addrs:     []string{"localhost:6379"},
+			TLSConfig: tlsConfig,
+		})
+
+		require.NotNil(t, opts.TLSConfig)
+		assert.Same(t, tlsConfig, opts.TLSConfig)
+	})
+}
+
+func TestToRedisOptionsCredentialsStillMapped(t *testing.T) {
+	opts := ToRedisOptions(&core.RedisCacheConfig{
+		Addr:     "localhost:6379",
+		Username: "user",
+		Password: "pass",
+		DB:       3,
+	})
+
+	assert.Equal(t, "user", opts.Username)
+	assert.Equal(t, "pass", opts.Password)
+	assert.Equal(t, 3, opts.DB)
+}
+
+func TestToRedisOptionsAddrAsURL(t *testing.T) {
+	t.Run("redis scheme is reduced to host:port", func(t *testing.T) {
+		opts := ToRedisOptions(&core.RedisCacheConfig{Addr: "redis://localhost:6379"})
+
+		assert.Equal(t, "localhost:6379", opts.Addr)
+		assert.Nil(t, opts.TLSConfig)
+	})
+
+	t.Run("rediss scheme implies TLS", func(t *testing.T) {
+		opts := ToRedisOptions(&core.RedisCacheConfig{Addr: "rediss://cache.example.com:6380"})
+
+		assert.Equal(t, "cache.example.com:6380", opts.Addr)
+		require.NotNil(t, opts.TLSConfig)
+		assert.Equal(t, "cache.example.com", opts.TLSConfig.ServerName)
+	})
+
+	t.Run("URL credentials and db are used when config omits them", func(t *testing.T) {
+		opts := ToRedisOptions(&core.RedisCacheConfig{Addr: "redis://user:pass@localhost:6379/4"})
+
+		assert.Equal(t, "localhost:6379", opts.Addr)
+		assert.Equal(t, "user", opts.Username)
+		assert.Equal(t, "pass", opts.Password)
+		assert.Equal(t, 4, opts.DB)
+	})
+
+	t.Run("explicit config wins over URL", func(t *testing.T) {
+		explicitTLS := &tls.Config{MinVersion: tls.VersionTLS13}
+		opts := ToRedisOptions(&core.RedisCacheConfig{
+			Addr:      "rediss://urluser:urlpass@cache.example.com:6380/4",
+			Username:  "configuser",
+			Password:  "configpass",
+			DB:        1,
+			TLSConfig: explicitTLS,
+		})
+
+		assert.Equal(t, "cache.example.com:6380", opts.Addr)
+		assert.Equal(t, "configuser", opts.Username)
+		assert.Equal(t, "configpass", opts.Password)
+		assert.Equal(t, 1, opts.DB)
+		assert.Same(t, explicitTLS, opts.TLSConfig)
+	})
+
+	t.Run("unparseable URL is left alone", func(t *testing.T) {
+		opts := ToRedisOptions(&core.RedisCacheConfig{Addr: "memcached://localhost:11211"})
+
+		assert.Equal(t, "memcached://localhost:11211", opts.Addr)
+	})
+}
+
+func TestBuildRedisClientUsesSuppliedClient(t *testing.T) {
+	supplied := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	t.Cleanup(func() { _ = supplied.Close() })
+
+	t.Run("by value", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: core.RedisClientConfig{Client: supplied},
+		})
+
+		assert.Same(t, supplied, client)
+	})
+
+	t.Run("by pointer", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisClientConfig{Client: supplied},
+		})
+
+		assert.Same(t, supplied, client)
+	})
+
+	t.Run("via WithRedisClient", func(t *testing.T) {
+		config := core.WithRedisClient(supplied)
+		client := buildRedisClient(&core.DatastreamOptions{CacheConfig: config})
+
+		assert.Same(t, supplied, client)
+	})
+}
+
+func TestBuildRedisClientWithoutConfig(t *testing.T) {
+	assert.Nil(t, buildRedisClient(nil))
+	assert.Nil(t, buildRedisClient(&core.DatastreamOptions{}))
+}

--- a/datastream/cache_tls_test.go
+++ b/datastream/cache_tls_test.go
@@ -1,0 +1,216 @@
+package datastream
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/schematichq/schematic-go/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startTLSRedisStub runs a TLS listener that speaks just enough RESP to answer
+// go-redis' connection handshake and a PING. It returns the address and a cert
+// pool that trusts it. A plaintext client cannot talk to it, so a successful
+// PING proves the TLS config reached the dialer.
+func startTLSRedisStub(t *testing.T) (addr string, roots *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	cert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	)
+	require.NoError(t, err)
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go serveRESP(conn)
+		}
+	}()
+
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	roots = x509.NewCertPool()
+	roots.AddCert(parsed)
+
+	return listener.Addr().String(), roots
+}
+
+// serveRESP answers PING with +PONG and everything else with a generic error,
+// which is all go-redis needs to consider the connection usable.
+func serveRESP(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	for {
+		args, err := readRESPCommand(reader)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			continue
+		}
+
+		reply := fmt.Sprintf("-ERR unknown command '%s'\r\n", args[0])
+		if strings.EqualFold(args[0], "PING") {
+			reply = "+PONG\r\n"
+		}
+		if _, err := conn.Write([]byte(reply)); err != nil {
+			return
+		}
+	}
+}
+
+func readRESPCommand(reader *bufio.Reader) ([]string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if len(line) < 2 || line[0] != '*' {
+		return nil, fmt.Errorf("expected array, got %q", line)
+	}
+
+	count, err := strconv.Atoi(line[1 : len(line)-2])
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if len(header) < 2 || header[0] != '$' {
+			return nil, fmt.Errorf("expected bulk string, got %q", header)
+		}
+
+		length, err := strconv.Atoi(header[1 : len(header)-2])
+		if err != nil {
+			return nil, err
+		}
+
+		buf := make([]byte, length+2) // payload plus trailing CRLF
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:length]))
+	}
+
+	return args, nil
+}
+
+// TestBuildRedisClientTLSHandshake exercises the whole path an encrypted
+// ElastiCache/Valkey cluster takes: a TLSConfig on the cache config has to
+// survive buildRedisClient and reach the dialer, or the handshake never happens.
+func TestBuildRedisClientTLSHandshake(t *testing.T) {
+	addr, roots := startTLSRedisStub(t)
+
+	t.Run("TLSConfig connects", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisCacheConfig{
+				Addr:        addr,
+				DialTimeout: 5 * time.Second,
+				ReadTimeout: 5 * time.Second,
+				TLSConfig:   &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
+			},
+		})
+		require.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("rediss URL connects without an explicit TLSConfig", func(t *testing.T) {
+		// The URL supplies TLS; RootCAs still has to be threaded in for the
+		// self-signed stub, but ServerName comes from the URL host.
+		opts := ToRedisOptions(&core.RedisCacheConfig{
+			Addr:        "rediss://" + addr,
+			DialTimeout: 5 * time.Second,
+			ReadTimeout: 5 * time.Second,
+		})
+		require.NotNil(t, opts.TLSConfig, "rediss scheme should imply TLS")
+		opts.TLSConfig.RootCAs = roots
+		opts.TLSConfig.ServerName = "localhost"
+
+		client := redis.NewClient(opts)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("nil TLSConfig cannot talk to an encrypted server", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisCacheConfig{
+				Addr:        addr,
+				DialTimeout: 2 * time.Second,
+				ReadTimeout: 2 * time.Second,
+				MaxRetries:  -1,
+			},
+		})
+		require.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := client.Ping(ctx).Result()
+		assert.Error(t, err, "a plaintext client should not reach a TLS-only server")
+	})
+}

--- a/option/custom_options.go
+++ b/option/custom_options.go
@@ -17,6 +17,7 @@ var WithLogger = core.WithLogger
 var WithLogLevel = core.WithLogLevel
 var WithDatastream = core.WithDatastream
 var WithRedisCache = core.WithRedisCache
+var WithRedisClient = core.WithRedisClient
 var WithCacheTTL = core.WithCacheTTL
 var WithReplicatorMode = core.WithReplicatorMode
 var WithReplicatorHealthURL = core.WithReplicatorHealthURL
@@ -24,6 +25,7 @@ var WithReplicatorHealthInterval = core.WithReplicatorHealthInterval
 
 type RedisCacheConfig = core.RedisCacheConfig
 type RedisCacheClusterConfig = core.RedisCacheClusterConfig
+type RedisClientConfig = core.RedisClientConfig
 type LogLevel = core.LogLevel
 
 const (


### PR DESCRIPTION
Unblocks re-enabling datastream flag checks on schematic-api, which were turned off in https://github.com/SchematicHQ/schematic-api/pull/7506 when the cache cluster moved to encrypted Valkey. `RedisCacheConfig` and `RedisCacheClusterConfig` mapped every other go-redis field but not `TLSConfig`, so there was no way to reach an encrypted server.

Three changes:

- `TLSConfig *tls.Config` on both cache configs, mapped through `ToRedisOptions` / `ToRedisClusterOptions`. Nil is go-redis' plaintext default, so existing callers are unaffected.
- `RedisClientConfig` / `WithRedisClient(redis.UniversalClient)`, so a caller can hand over a client it already builds rather than restate 24 fields. schematic-api's `redis.CreateClient` already sets maint-notifications, pool sizing and timeouts that the struct mapping doesn't cover, and the Python SDK works this way.
- `RedisCacheConfig.Addr` now accepts a `redis://` or `rediss://` URL as well as bare `host:port`. The single-instance path was unreachable for anyone passing a connection URL — schematic-api passes one today. Explicit config fields still win over anything the URL carries.

All four files are in `.fernignore`, so Fern regeneration won't clobber them.

`datastream/cache_tls_test.go` stands up a TLS listener with a self-signed cert and a minimal RESP responder, then PINGs it through `buildRedisClient` — so the encrypted path is exercised for real, not just asserted on the options struct. The nil-TLSConfig case fails against that same listener, which is the regression this is guarding. `datastream/cache_test.go` covers TLS propagation on both configs, client passthrough by value/pointer/helper, and the URL forms.

Verified locally with `go build ./...`, `go vet ./...`, `golangci-lint run` over the touched packages (0 issues), and `go test` over datastream/cache/client/flags, including `-race -count=3` on the new tests. Not verified against a real ElastiCache/Valkey endpoint.

Needs a tag before schematic-api can pick it up; note the api pins v1.5.4 and the WASM rules-engine migration (#191) has landed since, so that bump wants its own soak.