### PR TITLE
support TLS, connection URLs, and caller-supplied clients in the datastream Redis cache

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -33,6 +33,8 @@ client/schematic_client.go
 client/schematic_client_test.go
 client/logger_config_test.go
 datastream/cache.go
+datastream/cache_test.go
+datastream/cache_tls_test.go
 datastream/client.go
 datastream/resource_cache.go
 datastream/client_test.go

--- a/README.md
+++ b/README.md
@@ -579,6 +579,43 @@ options := &schematicoption.DatastreamOptions{
 }
 ```
 
+`Addr` also accepts a connection URL, or you can set `URL` to be explicit. A `rediss://`
+URL enables TLS with the server name taken from the host, so no `TLSConfig` is needed:
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheTTL: 5 * time.Minute,
+	CacheConfig: &schematicoption.RedisCacheConfig{
+		URL:         "rediss://user:password@cache.example.com:6379/0",
+		DialTimeout: 5 * time.Second, // Fields set here override what the URL derived
+	},
+}
+```
+
+A URL that does not parse, or that names no host, is logged as a warning and the
+datastream falls back to its local cache, rather than dialing an address you did not
+name. Credentials are redacted from that warning, and the underlying parse error is
+withheld from it entirely when the URL carries any — `net/url` quotes both the URL and
+fragments of it into its errors, so an unescaped `/` in a password ends up quoted back
+as an "invalid port".
+
+Fields set on the struct override what the URL derived, but only when they are non-zero,
+so a URL-derived setting cannot be switched back off here: drop it from the URL instead.
+
+To enable TLS against a plain `host:port` address, set `TLSConfig` yourself. An
+otherwise-empty config keeps hostname verification on and uses the system roots, which
+is what a publicly-trusted certificate (ElastiCache, for instance) needs:
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheTTL: 5 * time.Minute,
+	CacheConfig: &schematicoption.RedisCacheConfig{
+		Addr:      "cache.example.com:6379",
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	},
+}
+```
+
 #### 2. Redis Cluster
 
 To use a Redis cluster, create a `RedisCacheClusterConfig` and pass it to the `DatastreamOptions`.
@@ -600,6 +637,56 @@ options := &schematicoption.DatastreamOptions{
 	},
 }
 ```
+
+A cluster accepts a connection URL on the same terms as a single instance — its
+configuration endpoint, typically. Set `URL`, or leave a single scheme-bearing entry in
+`Addrs`; name any further nodes with go-redis' `?addr=` parameter, or as bare `host:port`
+entries beside the URL:
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheTTL: 5 * time.Minute,
+	CacheConfig: &schematicoption.RedisCacheClusterConfig{
+		URL: "rediss://user:password@clustercfg.example.com:6379?addr=node2.example.com:6379",
+	},
+}
+```
+
+`URL` takes precedence over `Addrs`, which is then ignored. Two scheme-bearing entries in
+`Addrs` is an error — each would carry its own credentials and TLS, with nothing to say
+which the cluster should use — and, like a URL that does not parse or names no host, it
+leaves the datastream on its local cache with a warning.
+
+For a cluster that requires TLS — an encrypted ElastiCache or Valkey cluster, say — set
+`TLSConfig`. It applies to every node, so seed `Addrs` with the cluster's configuration
+endpoint: slot discovery then returns hostnames the certificate covers.
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheTTL: 5 * time.Minute,
+	CacheConfig: &schematicoption.RedisCacheClusterConfig{
+		Addrs:     []string{"cache.example.com:6379"},
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	},
+}
+```
+
+#### 3. Bringing your own client
+
+If your application already builds a Redis client, hand it over whole rather than
+restating its settings field by field. The configs above map a fixed set of go-redis
+options; a client passed this way keeps everything, including what those configs
+cannot express — a custom dialer, hooks, or a tracing wrapper.
+
+```go
+options := &schematicoption.DatastreamOptions{
+	CacheTTL:    5 * time.Minute,
+	CacheConfig: schematicoption.WithRedisClient(myRedisClient), // any redis.UniversalClient
+}
+```
+
+The SDK shares the client across all of its caches and never closes it, so its
+lifecycle stays yours.
 
 ---
 

--- a/core/custom_options.go
+++ b/core/custom_options.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"crypto/tls"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/schematichq/schematic-go/cache"
 	"github.com/schematichq/schematic-go/http"
 )
@@ -166,6 +168,18 @@ type CacheConfig interface {
 }
 
 type RedisCacheConfig struct {
+	// URL is a Redis connection URL, e.g. redis://host:6379/0 or
+	// rediss://user:pass@host:6379 for TLS, which yields a TLSConfig with
+	// ServerName already set. It takes precedence over Addr, and an Addr carrying
+	// a scheme is treated as a URL too.
+	//
+	// Any field below set to a non-zero value overrides what the URL derived. Only
+	// non-zero ones, so a URL-derived setting cannot be turned back off here: drop
+	// it from the URL instead.
+	//
+	// A URL that does not parse, or names no host, leaves the datastream on its
+	// local cache rather than being dialed as-is.
+	URL                   string
 	Network               string
 	Addr                  string
 	ClientName            string
@@ -192,6 +206,9 @@ type RedisCacheConfig struct {
 	DisableIdentity       bool
 	IdentitySuffix        string
 	UnstableResp3         bool
+	// TLSConfig enables TLS for the connection. Nil, the zero value, means
+	// plaintext, which is go-redis' default.
+	TLSConfig *tls.Config
 }
 
 func (c RedisCacheConfig) applyDatastreamOptions(opts *DatastreamOptions) {
@@ -199,6 +216,15 @@ func (c RedisCacheConfig) applyDatastreamOptions(opts *DatastreamOptions) {
 }
 
 type RedisCacheClusterConfig struct {
+	// URL is a Redis connection URL for the cluster — an ElastiCache or Valkey
+	// configuration endpoint, typically. It follows RedisCacheConfig.URL's rules,
+	// and takes precedence over Addrs, which is then ignored; name further nodes
+	// with go-redis' ?addr=host:port parameter.
+	//
+	// A single entry in Addrs carrying a scheme is treated as this URL too, with
+	// the remaining bare entries kept as additional nodes. Two of them is an error:
+	// each carries its own credentials and TLS, with nothing to choose between them.
+	URL                   string
 	Addrs                 []string
 	MaxRedirects          int
 	RouteByLatency        bool
@@ -225,14 +251,40 @@ type RedisCacheClusterConfig struct {
 	DisableIdentity       bool
 	IdentitySuffix        string
 	UnstableResp3         bool
+	// TLSConfig enables TLS for connections to every node in the cluster. Nil,
+	// the zero value, means plaintext, which is go-redis' default.
+	TLSConfig *tls.Config
 }
 
 func (c RedisCacheClusterConfig) applyDatastreamOptions(opts *DatastreamOptions) {
 	opts.CacheConfig = c
 }
 
+// RedisClientConfig hands the datastream a Redis client the caller has already
+// built, instead of describing one field by field. Prefer it when the
+// application constructs its own client: the field-by-field configs map a fixed
+// set of go-redis options, so anything outside that set — a custom dialer, a
+// hook, a tracing wrapper — cannot be expressed through them at all.
+//
+// The SDK shares the client across every datastream cache and never closes it;
+// its lifecycle stays with the caller.
+type RedisClientConfig struct {
+	Client redis.UniversalClient
+}
+
+func (c RedisClientConfig) applyDatastreamOptions(opts *DatastreamOptions) {
+	opts.CacheConfig = c
+}
+
 func WithRedisCache(opts CacheConfig) CacheConfig {
 	return opts
+}
+
+// WithRedisClient wraps an existing Redis client as a datastream cache config.
+// The client may be any redis.UniversalClient — single-node, cluster or
+// failover.
+func WithRedisClient(client redis.UniversalClient) CacheConfig {
+	return RedisClientConfig{Client: client}
 }
 
 type ClientOptUseDatastream struct {

--- a/datastream/cache.go
+++ b/datastream/cache.go
@@ -1,6 +1,13 @@
 package datastream
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+
 	"github.com/redis/go-redis/v9"
 	"github.com/schematichq/schematic-go/cache"
 	"github.com/schematichq/schematic-go/core"
@@ -62,8 +69,9 @@ func buildLookupCacheProvider(configOpt *core.DatastreamOptions, redisClient red
 
 // buildRedisClient creates a Redis client from the cache configuration, or returns nil
 // if no Redis config is provided. The returned client should be shared across all cache
-// providers to respect the user's connection pool settings.
-func buildRedisClient(configOpt *core.DatastreamOptions) redis.UniversalClient {
+// providers to respect the user's connection pool settings. The logger, which may be
+// nil, receives a warning if a configured connection URL cannot be parsed.
+func buildRedisClient(configOpt *core.DatastreamOptions, logger core.Logger) redis.UniversalClient {
 	if configOpt == nil || configOpt.CacheConfig == nil {
 		return nil
 	}
@@ -71,19 +79,128 @@ func buildRedisClient(configOpt *core.DatastreamOptions) redis.UniversalClient {
 	switch configOpt.CacheConfig.(type) {
 	case *core.RedisCacheConfig:
 		config := configOpt.CacheConfig.(*core.RedisCacheConfig)
-		return redis.NewClient(ToRedisOptions(config))
+		return newRedisClient(config, logger)
 	case core.RedisCacheConfig:
 		config := configOpt.CacheConfig.(core.RedisCacheConfig)
-		return redis.NewClient(ToRedisOptions(&config))
+		return newRedisClient(&config, logger)
 	case *core.RedisCacheClusterConfig:
 		config := configOpt.CacheConfig.(*core.RedisCacheClusterConfig)
-		return redis.NewClusterClient(ToRedisClusterOptions(config))
+		return newRedisClusterClient(config, logger)
 	case core.RedisCacheClusterConfig:
 		config := configOpt.CacheConfig.(core.RedisCacheClusterConfig)
-		return redis.NewClusterClient(ToRedisClusterOptions(&config))
+		return newRedisClusterClient(&config, logger)
+	case *core.RedisClientConfig:
+		return callerSuppliedClient(configOpt.CacheConfig.(*core.RedisClientConfig).Client)
+	case core.RedisClientConfig:
+		return callerSuppliedClient(configOpt.CacheConfig.(core.RedisClientConfig).Client)
 	}
 
 	return nil
+}
+
+// callerSuppliedClient guards against a typed nil. A nil client means "no Redis" and
+// sends buildCacheProvidersFromConfig to the local cache, but a nil *redis.Client stored
+// in the interface is not nil and would panic on first use instead.
+func callerSuppliedClient(client redis.UniversalClient) redis.UniversalClient {
+	if client == nil || isNilValue(client) {
+		return nil
+	}
+
+	return client
+}
+
+// isNilValue reports whether the interface holds a nil pointer or other nilable zero.
+// The kind is checked first because reflect.Value.IsNil panics on kinds that cannot be
+// nil, and a caller implementing the interface by value must not blow up the constructor.
+func isNilValue(client redis.UniversalClient) bool {
+	value := reflect.ValueOf(client)
+
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan, reflect.UnsafePointer:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// newRedisClient builds a single-instance client, or nothing at all if the connection
+// URL is unusable. Dialing on regardless would mean go-redis' localhost:6379 default or
+// an address that never reached a Redis; returning nil degrades to the local cache
+// instead, the same path a nil config takes.
+func newRedisClient(config *core.RedisCacheConfig, logger core.Logger) redis.UniversalClient {
+	opts, err := toRedisOptions(config)
+	if err != nil {
+		if logger != nil {
+			connURL := redisConnectionURL(config)
+			logger.Warn(context.Background(), fmt.Sprintf(
+				"Could not parse Redis connection URL '%s', falling back to the local cache: %s",
+				redactRedisURL(connURL), redactRedisError(err, connURL)))
+		}
+
+		return nil
+	}
+
+	return redis.NewClient(opts)
+}
+
+// newRedisClusterClient builds a cluster client, declining an unusable URL for the same
+// reason newRedisClient does.
+func newRedisClusterClient(config *core.RedisCacheClusterConfig, logger core.Logger) redis.UniversalClient {
+	opts, err := toRedisClusterOptions(config)
+	if err != nil {
+		if logger != nil {
+			connURL, _, _ := clusterConnectionURL(config)
+			logger.Warn(context.Background(), fmt.Sprintf(
+				"Could not use Redis cluster connection URL '%s', falling back to the local cache: %s",
+				redactRedisURL(connURL), redactRedisError(err, connURL)))
+		}
+
+		return nil
+	}
+
+	return redis.NewClusterClient(opts)
+}
+
+// redactRedisURL blanks any credentials in a connection URL so it can be logged. The
+// URL is malformed by the time this runs, so it cannot lean on url.Parse; it drops
+// whatever sits before the last '@' of the authority instead.
+//
+// An unescaped '/' or '?' in a password hides that '@' from the scan, so a '@' beyond the
+// guessed authority is treated as proof the guess is wrong and the whole URL is elided.
+// Losing the host on a URL whose only '@' is in a query value is the cheaper mistake.
+func redactRedisURL(connURL string) string {
+	scheme, authority := "", connURL
+	if i := strings.Index(connURL, "://"); i >= 0 {
+		scheme, authority = connURL[:i+len("://")], connURL[i+len("://"):]
+	}
+
+	end := strings.IndexAny(authority, "/?")
+	if end < 0 {
+		end = len(authority)
+	}
+
+	at := strings.LastIndex(authority[:end], "@")
+	if at < 0 {
+		if strings.Contains(authority[end:], "@") {
+			return scheme + "redacted"
+		}
+
+		return connURL
+	}
+
+	return scheme + "redacted@" + authority[at+1:]
+}
+
+// redactRedisError reports how much of a parse failure is safe to log. The URL cannot be
+// scrubbed out of the error text: net/url quotes it in %q-escaped, defeating a literal
+// replacement, and quotes fragments besides — a password holding a '/' comes back named
+// as the invalid port. So the text is logged only when there is no userinfo to leak.
+func redactRedisError(err error, connURL string) string {
+	if strings.Contains(connURL, "@") {
+		return "error detail withheld because the URL carries credentials"
+	}
+
+	return err.Error()
 }
 
 // Helper function to build cache providers based on configuration options
@@ -120,64 +237,308 @@ func buildLocalCache(opt *core.DatastreamOptions) (CompanyCacheProvider, UserCac
 	return companyCacheProvider, userCacheProvider
 }
 
+// ToRedisOptions maps a cache config onto go-redis options, resolving a connection URL
+// when the config carries one. An unusable URL is left in Addr verbatim, so a client
+// built from these options fails loudly rather than against go-redis' localhost default.
 func ToRedisOptions(config *core.RedisCacheConfig) *redis.Options {
-	return &redis.Options{
-		Network:               config.Network,
-		Addr:                  config.Addr,
-		ClientName:            config.ClientName,
-		Protocol:              config.Protocol,
-		Username:              config.Username,
-		Password:              config.Password,
-		DB:                    config.DB,
-		MaxRetries:            config.MaxRetries,
-		MinRetryBackoff:       config.MinRetryBackoff,
-		MaxRetryBackoff:       config.MaxRetryBackoff,
-		DialTimeout:           config.DialTimeout,
-		ReadTimeout:           config.ReadTimeout,
-		WriteTimeout:          config.WriteTimeout,
-		ContextTimeoutEnabled: config.ContextTimeoutEnabled,
-		PoolFIFO:              config.PoolFIFO,
-		PoolSize:              config.PoolSize,
-		PoolTimeout:           config.PoolTimeout,
-		MinIdleConns:          config.MinIdleConns,
-		MaxIdleConns:          config.MaxIdleConns,
-		MaxActiveConns:        config.MaxActiveConns,
-		ConnMaxIdleTime:       config.ConnMaxIdleTime,
-		ConnMaxLifetime:       config.ConnMaxLifetime,
-		DisableIndentity:      config.DisableIndentity,
-		DisableIdentity:       config.DisableIdentity,
-		IdentitySuffix:        config.IdentitySuffix,
-		UnstableResp3:         config.UnstableResp3,
-	}
+	opts, _ := toRedisOptions(config)
+	return opts
 }
 
-func ToRedisClusterOptions(config *core.RedisCacheClusterConfig) *redis.ClusterOptions {
-	return &redis.ClusterOptions{
-		Addrs:                 config.Addrs,
-		MaxRedirects:          config.MaxRedirects,
-		RouteByLatency:        config.RouteByLatency,
-		RouteRandomly:         config.RouteRandomly,
-		Protocol:              config.Protocol,
-		Username:              config.Username,
-		Password:              config.Password,
-		MaxRetries:            config.MaxRetries,
-		MinRetryBackoff:       config.MinRetryBackoff,
-		MaxRetryBackoff:       config.MaxRetryBackoff,
-		DialTimeout:           config.DialTimeout,
-		ReadTimeout:           config.ReadTimeout,
-		WriteTimeout:          config.WriteTimeout,
-		ContextTimeoutEnabled: config.ContextTimeoutEnabled,
-		PoolFIFO:              config.PoolFIFO,
-		PoolSize:              config.PoolSize,
-		PoolTimeout:           config.PoolTimeout,
-		MinIdleConns:          config.MinIdleConns,
-		MaxIdleConns:          config.MaxIdleConns,
-		MaxActiveConns:        config.MaxActiveConns,
-		ConnMaxIdleTime:       config.ConnMaxIdleTime,
-		ConnMaxLifetime:       config.ConnMaxLifetime,
-		DisableIndentity:      config.DisableIndentity,
-		DisableIdentity:       config.DisableIdentity,
-		IdentitySuffix:        config.IdentitySuffix,
-		UnstableResp3:         config.UnstableResp3,
+// toRedisOptions is ToRedisOptions with the parse failure surfaced; the exported name is
+// public API and cannot grow a second return value. It always returns usable options.
+func toRedisOptions(config *core.RedisCacheConfig) (*redis.Options, error) {
+	connURL := redisConnectionURL(config)
+	if connURL == "" {
+		return applyRedisConfig(&redis.Options{Addr: config.Addr}, config), nil
 	}
+
+	parsed, err := redis.ParseURL(connURL)
+	if err == nil {
+		err = checkRedisURLHost(connURL)
+	}
+	if err != nil {
+		// connURL, never Addr: an empty Addr would become localhost:6379.
+		return applyRedisConfig(&redis.Options{Addr: connURL}, config), err
+	}
+
+	return applyRedisConfig(parsed, config), nil
+}
+
+// errRedisURLNoHost reports a connection URL that names no server to connect to.
+var errRedisURLNoHost = errors.New("redis: connection URL has no host")
+
+// checkRedisURLHost rejects a URL that names no host, which redis.ParseURL accepts and
+// turns into localhost:6379 — the shape an unset environment variable takes. A unix://
+// URL carries a socket path instead and is left alone.
+func checkRedisURLHost(connURL string) error {
+	parsed, err := url.Parse(connURL)
+	if err != nil || parsed.Scheme == "unix" {
+		return nil
+	}
+
+	if parsed.Hostname() == "" {
+		return errRedisURLNoHost
+	}
+
+	return nil
+}
+
+// redisConnectionURL reports the connection URL the config asks for, if any. Callers
+// may set URL, or leave a scheme-bearing string in Addr: go-redis wants a bare
+// host:port there, so such a value only ever reached net.Dial and failed, and treating
+// it as a URL breaks nothing that worked.
+func redisConnectionURL(config *core.RedisCacheConfig) string {
+	if config.URL != "" {
+		return config.URL
+	}
+
+	if strings.Contains(config.Addr, "://") {
+		return config.Addr
+	}
+
+	return ""
+}
+
+// applyRedisConfig overlays the config's non-zero fields onto opts, which may already
+// carry values a connection URL derived. Leaving zero values alone is what lets
+// URL-derived settings survive; on a fresh redis.Options it reproduces the previous
+// field-for-field mapping.
+func applyRedisConfig(opts *redis.Options, config *core.RedisCacheConfig) *redis.Options {
+	if config.Network != "" {
+		opts.Network = config.Network
+	}
+	if config.ClientName != "" {
+		opts.ClientName = config.ClientName
+	}
+	if config.Protocol != 0 {
+		opts.Protocol = config.Protocol
+	}
+	if config.Username != "" {
+		opts.Username = config.Username
+	}
+	if config.Password != "" {
+		opts.Password = config.Password
+	}
+	if config.DB != 0 {
+		opts.DB = config.DB
+	}
+	if config.MaxRetries != 0 {
+		opts.MaxRetries = config.MaxRetries
+	}
+	if config.MinRetryBackoff != 0 {
+		opts.MinRetryBackoff = config.MinRetryBackoff
+	}
+	if config.MaxRetryBackoff != 0 {
+		opts.MaxRetryBackoff = config.MaxRetryBackoff
+	}
+	if config.DialTimeout != 0 {
+		opts.DialTimeout = config.DialTimeout
+	}
+	if config.ReadTimeout != 0 {
+		opts.ReadTimeout = config.ReadTimeout
+	}
+	if config.WriteTimeout != 0 {
+		opts.WriteTimeout = config.WriteTimeout
+	}
+	if config.ContextTimeoutEnabled {
+		opts.ContextTimeoutEnabled = true
+	}
+	if config.PoolFIFO {
+		opts.PoolFIFO = true
+	}
+	if config.PoolSize != 0 {
+		opts.PoolSize = config.PoolSize
+	}
+	if config.PoolTimeout != 0 {
+		opts.PoolTimeout = config.PoolTimeout
+	}
+	if config.MinIdleConns != 0 {
+		opts.MinIdleConns = config.MinIdleConns
+	}
+	if config.MaxIdleConns != 0 {
+		opts.MaxIdleConns = config.MaxIdleConns
+	}
+	if config.MaxActiveConns != 0 {
+		opts.MaxActiveConns = config.MaxActiveConns
+	}
+	if config.ConnMaxIdleTime != 0 {
+		opts.ConnMaxIdleTime = config.ConnMaxIdleTime
+	}
+	if config.ConnMaxLifetime != 0 {
+		opts.ConnMaxLifetime = config.ConnMaxLifetime
+	}
+	if config.DisableIndentity {
+		//nolint:staticcheck // the config still exposes go-redis' misspelled field; keep mapping it
+		opts.DisableIndentity = true
+	}
+	if config.DisableIdentity {
+		opts.DisableIdentity = true
+	}
+	if config.IdentitySuffix != "" {
+		opts.IdentitySuffix = config.IdentitySuffix
+	}
+	if config.UnstableResp3 {
+		//nolint:staticcheck // deprecated no-op in go-redis, but the config still exposes it
+		opts.UnstableResp3 = true
+	}
+	if config.TLSConfig != nil {
+		opts.TLSConfig = config.TLSConfig
+	}
+
+	return opts
+}
+
+// ToRedisClusterOptions maps a cluster cache config onto go-redis options, resolving a
+// connection URL when the config carries one. An unusable URL is left in Addrs verbatim,
+// so a client built from these options fails loudly rather than against go-redis'
+// localhost default.
+func ToRedisClusterOptions(config *core.RedisCacheClusterConfig) *redis.ClusterOptions {
+	opts, _ := toRedisClusterOptions(config)
+	return opts
+}
+
+// toRedisClusterOptions is ToRedisClusterOptions with the parse failure surfaced, split
+// out for the same reason toRedisOptions is.
+func toRedisClusterOptions(config *core.RedisCacheClusterConfig) (*redis.ClusterOptions, error) {
+	connURL, addrs, err := clusterConnectionURL(config)
+	if err != nil {
+		return applyRedisClusterConfig(&redis.ClusterOptions{Addrs: config.Addrs}, config), err
+	}
+
+	if connURL == "" {
+		return applyRedisClusterConfig(&redis.ClusterOptions{Addrs: config.Addrs}, config), nil
+	}
+
+	parsed, err := redis.ParseClusterURL(connURL)
+	if err == nil {
+		err = checkRedisURLHost(connURL)
+	}
+	if err != nil {
+		// connURL, never Addrs: an empty Addrs would become localhost:6379.
+		return applyRedisClusterConfig(&redis.ClusterOptions{Addrs: []string{connURL}}, config), err
+	}
+
+	parsed.Addrs = append(parsed.Addrs, addrs...)
+
+	return applyRedisClusterConfig(parsed, config), nil
+}
+
+// errRedisMultipleClusterURLs reports a config naming more than one connection URL.
+var errRedisMultipleClusterURLs = errors.New("redis: cluster config names more than one connection URL")
+
+// clusterConnectionURL reports the cluster's connection URL, if any, with the bare
+// host:port entries that belong beside it. URL wins outright; otherwise a lone
+// scheme-bearing entry in Addrs is the URL. Two of them carry two sets of credentials
+// and TLS, with nothing to choose between them.
+func clusterConnectionURL(config *core.RedisCacheClusterConfig) (connURL string, addrs []string, err error) {
+	if config.URL != "" {
+		return config.URL, nil, nil
+	}
+
+	for _, addr := range config.Addrs {
+		if !strings.Contains(addr, "://") {
+			addrs = append(addrs, addr)
+			continue
+		}
+
+		if connURL != "" {
+			return connURL, addrs, errRedisMultipleClusterURLs
+		}
+
+		connURL = addr
+	}
+
+	if connURL == "" {
+		return "", nil, nil
+	}
+
+	return connURL, addrs, nil
+}
+
+// applyRedisClusterConfig is applyRedisConfig for a cluster. Addrs is not among the
+// fields it overlays: the URL and the bare entries beside it have already settled that.
+func applyRedisClusterConfig(opts *redis.ClusterOptions, config *core.RedisCacheClusterConfig) *redis.ClusterOptions {
+	if config.MaxRedirects != 0 {
+		opts.MaxRedirects = config.MaxRedirects
+	}
+	if config.RouteByLatency {
+		opts.RouteByLatency = true
+	}
+	if config.RouteRandomly {
+		opts.RouteRandomly = true
+	}
+	if config.Protocol != 0 {
+		opts.Protocol = config.Protocol
+	}
+	if config.Username != "" {
+		opts.Username = config.Username
+	}
+	if config.Password != "" {
+		opts.Password = config.Password
+	}
+	if config.MaxRetries != 0 {
+		opts.MaxRetries = config.MaxRetries
+	}
+	if config.MinRetryBackoff != 0 {
+		opts.MinRetryBackoff = config.MinRetryBackoff
+	}
+	if config.MaxRetryBackoff != 0 {
+		opts.MaxRetryBackoff = config.MaxRetryBackoff
+	}
+	if config.DialTimeout != 0 {
+		opts.DialTimeout = config.DialTimeout
+	}
+	if config.ReadTimeout != 0 {
+		opts.ReadTimeout = config.ReadTimeout
+	}
+	if config.WriteTimeout != 0 {
+		opts.WriteTimeout = config.WriteTimeout
+	}
+	if config.ContextTimeoutEnabled {
+		opts.ContextTimeoutEnabled = true
+	}
+	if config.PoolFIFO {
+		opts.PoolFIFO = true
+	}
+	if config.PoolSize != 0 {
+		opts.PoolSize = config.PoolSize
+	}
+	if config.PoolTimeout != 0 {
+		opts.PoolTimeout = config.PoolTimeout
+	}
+	if config.MinIdleConns != 0 {
+		opts.MinIdleConns = config.MinIdleConns
+	}
+	if config.MaxIdleConns != 0 {
+		opts.MaxIdleConns = config.MaxIdleConns
+	}
+	if config.MaxActiveConns != 0 {
+		opts.MaxActiveConns = config.MaxActiveConns
+	}
+	if config.ConnMaxIdleTime != 0 {
+		opts.ConnMaxIdleTime = config.ConnMaxIdleTime
+	}
+	if config.ConnMaxLifetime != 0 {
+		opts.ConnMaxLifetime = config.ConnMaxLifetime
+	}
+	if config.DisableIndentity {
+		//nolint:staticcheck // the config still exposes go-redis' misspelled field; keep mapping it
+		opts.DisableIndentity = true
+	}
+	if config.DisableIdentity {
+		opts.DisableIdentity = true
+	}
+	if config.IdentitySuffix != "" {
+		opts.IdentitySuffix = config.IdentitySuffix
+	}
+	if config.UnstableResp3 {
+		//nolint:staticcheck // deprecated no-op in go-redis, but the config still exposes it
+		opts.UnstableResp3 = true
+	}
+	if config.TLSConfig != nil {
+		opts.TLSConfig = config.TLSConfig
+	}
+
+	return opts
 }

--- a/datastream/cache_test.go
+++ b/datastream/cache_test.go
@@ -1,0 +1,617 @@
+package datastream
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/schematichq/schematic-go/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingLogger captures warnings so the malformed-URL path can be asserted on.
+type recordingLogger struct {
+	warnings []string
+}
+
+func (l *recordingLogger) Debug(context.Context, string, ...any) {}
+func (l *recordingLogger) Info(context.Context, string, ...any)  {}
+func (l *recordingLogger) Error(context.Context, string, ...any) {}
+func (l *recordingLogger) Warn(_ context.Context, message string, _ ...any) {
+	l.warnings = append(l.warnings, message)
+}
+
+func TestToRedisOptionsBareAddress(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	config := &core.RedisCacheConfig{
+		Network:               "tcp",
+		Addr:                  "localhost:6379",
+		ClientName:            "schematic",
+		Protocol:              3,
+		Username:              "user",
+		Password:              "secret",
+		DB:                    4,
+		MaxRetries:            3,
+		MinRetryBackoff:       time.Millisecond,
+		MaxRetryBackoff:       2 * time.Millisecond,
+		DialTimeout:           5 * time.Second,
+		ReadTimeout:           3 * time.Second,
+		WriteTimeout:          4 * time.Second,
+		ContextTimeoutEnabled: true,
+		PoolFIFO:              true,
+		PoolSize:              10,
+		PoolTimeout:           6 * time.Second,
+		MinIdleConns:          1,
+		MaxIdleConns:          2,
+		MaxActiveConns:        20,
+		ConnMaxIdleTime:       7 * time.Second,
+		ConnMaxLifetime:       8 * time.Second,
+		DisableIndentity:      true,
+		DisableIdentity:       true,
+		IdentitySuffix:        "suffix",
+		UnstableResp3:         true,
+		TLSConfig:             tlsConfig,
+	}
+
+	opts, err := toRedisOptions(config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tcp", opts.Network)
+	assert.Equal(t, "localhost:6379", opts.Addr)
+	assert.Equal(t, "schematic", opts.ClientName)
+	assert.Equal(t, 3, opts.Protocol)
+	assert.Equal(t, "user", opts.Username)
+	assert.Equal(t, "secret", opts.Password)
+	assert.Equal(t, 4, opts.DB)
+	assert.Equal(t, 3, opts.MaxRetries)
+	assert.Equal(t, time.Millisecond, opts.MinRetryBackoff)
+	assert.Equal(t, 2*time.Millisecond, opts.MaxRetryBackoff)
+	assert.Equal(t, 5*time.Second, opts.DialTimeout)
+	assert.Equal(t, 3*time.Second, opts.ReadTimeout)
+	assert.Equal(t, 4*time.Second, opts.WriteTimeout)
+	assert.True(t, opts.ContextTimeoutEnabled)
+	assert.True(t, opts.PoolFIFO)
+	assert.Equal(t, 10, opts.PoolSize)
+	assert.Equal(t, 6*time.Second, opts.PoolTimeout)
+	assert.Equal(t, 1, opts.MinIdleConns)
+	assert.Equal(t, 2, opts.MaxIdleConns)
+	assert.Equal(t, 20, opts.MaxActiveConns)
+	assert.Equal(t, 7*time.Second, opts.ConnMaxIdleTime)
+	assert.Equal(t, 8*time.Second, opts.ConnMaxLifetime)
+	assert.True(t, opts.DisableIndentity) //nolint:staticcheck // deprecated in go-redis, still mapped
+	assert.True(t, opts.DisableIdentity)
+	assert.Equal(t, "suffix", opts.IdentitySuffix)
+	assert.True(t, opts.UnstableResp3) //nolint:staticcheck // deprecated in go-redis, still mapped
+	assert.Same(t, tlsConfig, opts.TLSConfig)
+}
+
+func TestToRedisOptionsDefaultsToPlaintext(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{Addr: "localhost:6379"})
+
+	require.NoError(t, err)
+	assert.Nil(t, opts.TLSConfig)
+}
+
+func TestToRedisOptionsParsesSchemeInAddr(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{Addr: "redis://localhost:6379/2"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:6379", opts.Addr)
+	assert.Equal(t, 2, opts.DB)
+	assert.Nil(t, opts.TLSConfig)
+}
+
+func TestToRedisOptionsParsesRedissAddr(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{Addr: "rediss://user:secret@cache.example.com:6379"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cache.example.com:6379", opts.Addr)
+	assert.Equal(t, "user", opts.Username)
+	assert.Equal(t, "secret", opts.Password)
+	require.NotNil(t, opts.TLSConfig)
+	assert.Equal(t, "cache.example.com", opts.TLSConfig.ServerName)
+}
+
+func TestToRedisOptionsURLFieldWinsOverAddr(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{
+		URL:  "rediss://cache.example.com:6379",
+		Addr: "localhost:6379",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cache.example.com:6379", opts.Addr)
+	assert.NotNil(t, opts.TLSConfig)
+}
+
+func TestToRedisOptionsExplicitFieldsOverrideURL(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
+
+	opts, err := toRedisOptions(&core.RedisCacheConfig{
+		URL:         "rediss://urluser:urlsecret@cache.example.com:6379/1",
+		Username:    "configuser",
+		Password:    "configsecret",
+		DB:          7,
+		TLSConfig:   tlsConfig,
+		DialTimeout: 5 * time.Second,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "configuser", opts.Username)
+	assert.Equal(t, "configsecret", opts.Password)
+	assert.Equal(t, 7, opts.DB)
+	assert.Same(t, tlsConfig, opts.TLSConfig)
+	assert.Equal(t, 5*time.Second, opts.DialTimeout)
+}
+
+func TestToRedisOptionsKeepsURLDerivedValuesWhenConfigIsZero(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{
+		URL: "redis://urluser:urlsecret@cache.example.com:6379/1?dial_timeout=9s",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "urluser", opts.Username)
+	assert.Equal(t, "urlsecret", opts.Password)
+	assert.Equal(t, 1, opts.DB)
+	assert.Equal(t, 9*time.Second, opts.DialTimeout)
+}
+
+func TestToRedisOptionsMalformedURLFallsBack(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{
+		Addr:     "http://localhost:6379",
+		PoolSize: 12,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "http://localhost:6379", opts.Addr)
+	assert.Equal(t, 12, opts.PoolSize)
+}
+
+func TestNewRedisClientWarnsOnMalformedURL(t *testing.T) {
+	logger := &recordingLogger{}
+
+	// A nil client is the signal buildCacheProvidersFromConfig reads as "use the
+	// local cache".
+	client := newRedisClient(&core.RedisCacheConfig{Addr: "http://localhost:6379"}, logger)
+
+	assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+	require.Len(t, logger.warnings, 1)
+	assert.Contains(t, logger.warnings[0], "http://localhost:6379")
+	assert.Contains(t, logger.warnings[0], "local cache")
+}
+
+// With the URL in the URL field, Addr is empty, and go-redis turns an empty Addr into
+// localhost:6379 — so a typo would dial whatever Redis runs beside the application.
+func TestNewRedisClientMalformedURLDoesNotDialLocalhost(t *testing.T) {
+	logger := &recordingLogger{}
+
+	client := newRedisClient(&core.RedisCacheConfig{URL: "cache.example.com:6379"}, logger)
+
+	assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+	require.Len(t, logger.warnings, 1)
+	assert.Contains(t, logger.warnings[0], "cache.example.com:6379")
+	assert.NotContains(t, logger.warnings[0], "localhost")
+}
+
+// The URL that failed to parse may carry a password, and is about to reach the logs.
+func TestNewRedisClientRedactsCredentials(t *testing.T) {
+	logger := &recordingLogger{}
+
+	client := newRedisClient(&core.RedisCacheConfig{
+		URL: "rediss://user:hunter2@cache.example.com:6379/not-a-number",
+	}, logger)
+
+	assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+	require.Len(t, logger.warnings, 1)
+	assert.NotContains(t, logger.warnings[0], "hunter2")
+	assert.NotContains(t, logger.warnings[0], "user:")
+	assert.Contains(t, logger.warnings[0], "rediss://redacted@cache.example.com:6379/not-a-number")
+}
+
+func TestRedactRedisURL(t *testing.T) {
+	tests := map[string]struct{ redacted string }{
+		"rediss://user:secret@cache.example.com:6379/0": {"rediss://redacted@cache.example.com:6379/0"},
+		"redis://user:secret@cache.example.com:6379":    {"redis://redacted@cache.example.com:6379"},
+		"user:secret@cache.example.com:6379":            {"redacted@cache.example.com:6379"},
+		"redis://cache.example.com:6379/0":              {"redis://cache.example.com:6379/0"},
+		"cache.example.com:6379":                        {"cache.example.com:6379"},
+		"":                                              {""},
+		// A '/' or '?' in the password hides the userinfo '@'; the stray '@' beyond the
+		// guessed authority is the tell, and the whole URL goes.
+		"redis://user:pa/ss@cache.example.com:6379":  {"redis://redacted"},
+		"rediss://user:se?cret@cache.example.com:63": {"rediss://redacted"},
+		// The same tell fires on a query-value '@', costing the host. That is the trade.
+		"redis://cache.example.com:6379/0?client_name=a@b": {"redis://redacted"},
+	}
+
+	for input, expected := range tests {
+		assert.Equal(t, expected.redacted, redactRedisURL(input), "input %q", input)
+	}
+}
+
+// The parse error is the harder half of the warning: net/url quotes the URL into it
+// %q-escaped, and quotes fragments besides — "invalid port" names whatever sat where the
+// port should have been, which for a password holding a '/' is the password.
+func TestNewRedisClientRedactsCredentialsInErrorText(t *testing.T) {
+	for _, connURL := range []string{
+		// A control character is what makes url.Parse fail *and* what makes %q escape.
+		"redis://user:hunter2@cache.example.com:6379/\x7f",
+		"redis://user:hun\x7fter2@cache.example.com:6379",
+		// The '/' leaves the password where net/url expects a port.
+		"redis://user:hunter2/x@cache.example.com:6379",
+		"redis://user:hunter2?x@cache.example.com:6379",
+	} {
+		t.Run(connURL, func(t *testing.T) {
+			logger := &recordingLogger{}
+
+			client := newRedisClient(&core.RedisCacheConfig{URL: connURL}, logger)
+
+			assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+			require.Len(t, logger.warnings, 1)
+			assert.NotContains(t, logger.warnings[0], "hunter2")
+			assert.NotContains(t, logger.warnings[0], "hun")
+			assert.NotContains(t, logger.warnings[0], "user")
+		})
+	}
+}
+
+// A URL with no userinfo has nothing to leak, so it keeps the diagnostic in full.
+func TestNewRedisClientKeepsErrorDetailWithoutCredentials(t *testing.T) {
+	logger := &recordingLogger{}
+
+	newRedisClient(&core.RedisCacheConfig{URL: "http://cache.example.com:6379"}, logger)
+
+	require.Len(t, logger.warnings, 1)
+	assert.Contains(t, logger.warnings[0], "invalid URL scheme")
+}
+
+// The other way a URL reaches localhost:6379: redis.ParseURL accepts a hostless URL and
+// defaults it, so a half-written one parses cleanly and dials the wrong server.
+func TestNewRedisClientRejectsHostlessURL(t *testing.T) {
+	for _, connURL := range []string{"redis://", "redis:///0", "rediss://"} {
+		t.Run(connURL, func(t *testing.T) {
+			logger := &recordingLogger{}
+
+			client := newRedisClient(&core.RedisCacheConfig{URL: connURL}, logger)
+
+			assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+			require.Len(t, logger.warnings, 1)
+			assert.Contains(t, logger.warnings[0], "local cache")
+			assert.NotContains(t, logger.warnings[0], "localhost")
+		})
+	}
+}
+
+// A unix:// URL has no host by design; the hostless check must not swallow it.
+func TestToRedisOptionsAcceptsUnixSocketURL(t *testing.T) {
+	opts, err := toRedisOptions(&core.RedisCacheConfig{URL: "unix:///var/run/redis.sock"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "unix", opts.Network)
+	assert.Equal(t, "/var/run/redis.sock", opts.Addr)
+}
+
+func TestNewRedisClientToleratesNilLogger(t *testing.T) {
+	assert.NotPanics(t, func() {
+		newRedisClient(&core.RedisCacheConfig{Addr: "http://localhost:6379"}, nil)
+	})
+}
+
+func TestNewRedisClientDoesNotWarnOnValidConfig(t *testing.T) {
+	logger := &recordingLogger{}
+
+	client := newRedisClient(&core.RedisCacheConfig{Addr: "rediss://cache.example.com:6379"}, logger)
+	require.NotNil(t, client)
+	t.Cleanup(func() { _ = client.Close() })
+
+	assert.Empty(t, logger.warnings)
+}
+
+func TestToRedisClusterOptionsBareAddrs(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	config := &core.RedisCacheClusterConfig{
+		Addrs:                 []string{"one.example.com:6379", "two.example.com:6379"},
+		MaxRedirects:          5,
+		RouteByLatency:        true,
+		RouteRandomly:         true,
+		Protocol:              3,
+		Username:              "user",
+		Password:              "secret",
+		MaxRetries:            3,
+		MinRetryBackoff:       time.Millisecond,
+		MaxRetryBackoff:       2 * time.Millisecond,
+		DialTimeout:           5 * time.Second,
+		ReadTimeout:           3 * time.Second,
+		WriteTimeout:          4 * time.Second,
+		ContextTimeoutEnabled: true,
+		PoolFIFO:              true,
+		PoolSize:              10,
+		PoolTimeout:           6 * time.Second,
+		MinIdleConns:          1,
+		MaxIdleConns:          2,
+		MaxActiveConns:        20,
+		ConnMaxIdleTime:       7 * time.Second,
+		ConnMaxLifetime:       8 * time.Second,
+		DisableIndentity:      true,
+		DisableIdentity:       true,
+		IdentitySuffix:        "suffix",
+		UnstableResp3:         true,
+		TLSConfig:             tlsConfig,
+	}
+
+	opts, err := toRedisClusterOptions(config)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"one.example.com:6379", "two.example.com:6379"}, opts.Addrs)
+	assert.Equal(t, 5, opts.MaxRedirects)
+	assert.True(t, opts.RouteByLatency)
+	assert.True(t, opts.RouteRandomly)
+	assert.Equal(t, 3, opts.Protocol)
+	assert.Equal(t, "user", opts.Username)
+	assert.Equal(t, "secret", opts.Password)
+	assert.Equal(t, 3, opts.MaxRetries)
+	assert.Equal(t, time.Millisecond, opts.MinRetryBackoff)
+	assert.Equal(t, 2*time.Millisecond, opts.MaxRetryBackoff)
+	assert.Equal(t, 5*time.Second, opts.DialTimeout)
+	assert.Equal(t, 3*time.Second, opts.ReadTimeout)
+	assert.Equal(t, 4*time.Second, opts.WriteTimeout)
+	assert.True(t, opts.ContextTimeoutEnabled)
+	assert.True(t, opts.PoolFIFO)
+	assert.Equal(t, 10, opts.PoolSize)
+	assert.Equal(t, 6*time.Second, opts.PoolTimeout)
+	assert.Equal(t, 1, opts.MinIdleConns)
+	assert.Equal(t, 2, opts.MaxIdleConns)
+	assert.Equal(t, 20, opts.MaxActiveConns)
+	assert.Equal(t, 7*time.Second, opts.ConnMaxIdleTime)
+	assert.Equal(t, 8*time.Second, opts.ConnMaxLifetime)
+	assert.True(t, opts.DisableIndentity) //nolint:staticcheck // deprecated in go-redis, still mapped
+	assert.True(t, opts.DisableIdentity)
+	assert.Equal(t, "suffix", opts.IdentitySuffix)
+	assert.True(t, opts.UnstableResp3) //nolint:staticcheck // deprecated in go-redis, still mapped
+	assert.Same(t, tlsConfig, opts.TLSConfig)
+}
+
+func TestToRedisClusterOptionsParsesSchemeInAddrs(t *testing.T) {
+	opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		Addrs: []string{"rediss://user:secret@clustercfg.example.com:6379"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"clustercfg.example.com:6379"}, opts.Addrs)
+	assert.Equal(t, "user", opts.Username)
+	assert.Equal(t, "secret", opts.Password)
+	require.NotNil(t, opts.TLSConfig)
+	assert.Equal(t, "clustercfg.example.com", opts.TLSConfig.ServerName)
+}
+
+// A URL beside bare entries names one node; the bare ones name the rest.
+func TestToRedisClusterOptionsKeepsBareAddrsBesideURL(t *testing.T) {
+	opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		Addrs: []string{"redis://one.example.com:6379", "two.example.com:6379"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one.example.com:6379", "two.example.com:6379"}, opts.Addrs)
+}
+
+// go-redis' own way of naming extra nodes on a cluster URL.
+func TestToRedisClusterOptionsHonoursAddrQueryParam(t *testing.T) {
+	opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		URL: "redis://one.example.com:6379?addr=two.example.com:6379",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one.example.com:6379", "two.example.com:6379"}, opts.Addrs)
+}
+
+func TestToRedisClusterOptionsURLFieldWinsOverAddrs(t *testing.T) {
+	opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		URL:   "rediss://clustercfg.example.com:6379",
+		Addrs: []string{"ignored.example.com:6379"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"clustercfg.example.com:6379"}, opts.Addrs)
+	assert.NotNil(t, opts.TLSConfig)
+}
+
+func TestToRedisClusterOptionsExplicitFieldsOverrideURL(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
+
+	opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		URL:         "rediss://urluser:urlsecret@clustercfg.example.com:6379?max_retries=2",
+		Username:    "configuser",
+		Password:    "configsecret",
+		MaxRetries:  5,
+		TLSConfig:   tlsConfig,
+		DialTimeout: 5 * time.Second,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "configuser", opts.Username)
+	assert.Equal(t, "configsecret", opts.Password)
+	assert.Equal(t, 5, opts.MaxRetries)
+	assert.Same(t, tlsConfig, opts.TLSConfig)
+	assert.Equal(t, 5*time.Second, opts.DialTimeout)
+}
+
+func TestToRedisClusterOptionsKeepsURLDerivedValuesWhenConfigIsZero(t *testing.T) {
+	opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		URL: "redis://urluser:urlsecret@clustercfg.example.com:6379?max_retries=2&dial_timeout=9s",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "urluser", opts.Username)
+	assert.Equal(t, "urlsecret", opts.Password)
+	assert.Equal(t, 2, opts.MaxRetries)
+	assert.Equal(t, 9*time.Second, opts.DialTimeout)
+}
+
+// Two URLs carry two sets of credentials and TLS, so the config is refused outright.
+func TestToRedisClusterOptionsRejectsTwoURLs(t *testing.T) {
+	_, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+		Addrs: []string{"rediss://one.example.com:6379", "rediss://two.example.com:6379"},
+	})
+
+	require.ErrorIs(t, err, errRedisMultipleClusterURLs)
+}
+
+func TestNewRedisClusterClientFallsBack(t *testing.T) {
+	tests := map[string]struct {
+		config  *core.RedisCacheClusterConfig
+		warning string
+	}{
+		"malformed URL": {
+			config:  &core.RedisCacheClusterConfig{URL: "http://clustercfg.example.com:6379"},
+			warning: "invalid URL scheme",
+		},
+		"hostless URL": {
+			config:  &core.RedisCacheClusterConfig{URL: "redis://"},
+			warning: "no host",
+		},
+		"scheme in Addrs": {
+			config:  &core.RedisCacheClusterConfig{Addrs: []string{"http://clustercfg.example.com:6379"}},
+			warning: "invalid URL scheme",
+		},
+		"two URLs": {
+			config: &core.RedisCacheClusterConfig{Addrs: []string{
+				"rediss://one.example.com:6379",
+				"rediss://two.example.com:6379",
+			}},
+			warning: "more than one connection URL",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := &recordingLogger{}
+
+			client := newRedisClusterClient(test.config, logger)
+
+			assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+			require.Len(t, logger.warnings, 1)
+			assert.Contains(t, logger.warnings[0], test.warning)
+			assert.Contains(t, logger.warnings[0], "local cache")
+			assert.NotContains(t, logger.warnings[0], "localhost")
+		})
+	}
+}
+
+func TestNewRedisClusterClientRedactsCredentials(t *testing.T) {
+	logger := &recordingLogger{}
+
+	// ParseClusterURL rejects an unknown query parameter; it ignores the path outright,
+	// there being no DB to select on a cluster.
+	client := newRedisClusterClient(&core.RedisCacheClusterConfig{
+		URL: "rediss://user:hunter2@clustercfg.example.com:6379?not_a_param=1",
+	}, logger)
+
+	assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+	require.Len(t, logger.warnings, 1)
+	assert.NotContains(t, logger.warnings[0], "hunter2")
+	assert.NotContains(t, logger.warnings[0], "user")
+	assert.Contains(t, logger.warnings[0], "rediss://redacted@clustercfg.example.com:6379")
+}
+
+func TestBuildRedisClientClusterURL(t *testing.T) {
+	t.Run("builds from a URL", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: core.RedisCacheClusterConfig{URL: "rediss://clustercfg.example.com:6379"},
+		}, nil)
+
+		require.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+		assert.IsType(t, &redis.ClusterClient{}, client)
+	})
+
+	t.Run("declines an unusable URL", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisCacheClusterConfig{URL: "http://clustercfg.example.com:6379"},
+		}, nil)
+
+		assert.True(t, client == nil, "expected an untyped nil, got %#v", client)
+	})
+}
+
+func TestToRedisClusterOptionsTLSConfig(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	withTLS := ToRedisClusterOptions(&core.RedisCacheClusterConfig{
+		Addrs:     []string{"cache.example.com:6379"},
+		TLSConfig: tlsConfig,
+	})
+	assert.Same(t, tlsConfig, withTLS.TLSConfig)
+
+	withoutTLS := ToRedisClusterOptions(&core.RedisCacheClusterConfig{
+		Addrs: []string{"cache.example.com:6379"},
+	})
+	assert.Nil(t, withoutTLS.TLSConfig)
+}
+
+// The WithRedisClient path: the client is shared rather than rebuilt.
+func TestBuildRedisClientCallerSupplied(t *testing.T) {
+	t.Run("shares the client", func(t *testing.T) {
+		own := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		t.Cleanup(func() { _ = own.Close() })
+
+		assert.Same(t, own, buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: core.WithRedisClient(own),
+		}, nil))
+	})
+
+	t.Run("accepts the config by pointer", func(t *testing.T) {
+		own := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		t.Cleanup(func() { _ = own.Close() })
+
+		assert.Same(t, own, buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisClientConfig{Client: own},
+		}, nil))
+	})
+
+	t.Run("nil client falls back to the local cache", func(t *testing.T) {
+		got := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: core.WithRedisClient(nil),
+		}, nil)
+
+		// Compared with ==, not assert.Nil, which reports a typed nil pointer as nil
+		// too and so cannot tell the two apart.
+		assert.True(t, got == nil, "expected an untyped nil, got %#v", got)
+	})
+
+	t.Run("a non-pointer implementation is used as-is", func(t *testing.T) {
+		// reflect.Value.IsNil panics on a kind that cannot be nil, so a client
+		// implementing the interface by value must be recognised without it.
+		own := valueClient{redis.NewClient(&redis.Options{Addr: "localhost:6379"})}
+		t.Cleanup(func() { _ = own.Close() })
+
+		var got redis.UniversalClient
+		require.NotPanics(t, func() {
+			got = buildRedisClient(&core.DatastreamOptions{
+				CacheConfig: core.WithRedisClient(own),
+			}, nil)
+		})
+		assert.Equal(t, own, got)
+	})
+
+	t.Run("typed-nil client falls back to the local cache", func(t *testing.T) {
+		// A (*redis.Client)(nil) in the interface is not == nil, so without the
+		// reflect guard this reaches the caches and panics on first command.
+		var typedNil *redis.Client
+
+		got := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: core.WithRedisClient(typedNil),
+		}, nil)
+
+		assert.True(t, got == nil, "expected an untyped nil, got %#v", got)
+	})
+}
+
+// valueClient implements redis.UniversalClient with a struct rather than a pointer,
+// which is what makes an unguarded reflect.Value.IsNil panic.
+type valueClient struct {
+	redis.UniversalClient
+}

--- a/datastream/cache_tls_test.go
+++ b/datastream/cache_tls_test.go
@@ -1,0 +1,306 @@
+package datastream
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/schematichq/schematic-go/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startTLSRedisStub runs a TLS listener that speaks just enough RESP to answer
+// go-redis' connection handshake and a PING. It returns the address and a cert
+// pool that trusts it. A plaintext client cannot talk to it, so a successful
+// PING proves the TLS config reached the dialer.
+func startTLSRedisStub(t *testing.T) (addr string, roots *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	cert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	)
+	require.NoError(t, err)
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go serveRESP(conn, listener.Addr().String())
+		}
+	}()
+
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	roots = x509.NewCertPool()
+	roots.AddCert(parsed)
+
+	return listener.Addr().String(), roots
+}
+
+// serveRESP answers PING with +PONG, CLUSTER SLOTS with a single-node topology, and
+// everything else with a generic error, which is all go-redis needs to consider the
+// connection usable. own is the listener's address, which the slot map has to name so
+// that a cluster client dials this same stub for the node it is told about.
+func serveRESP(conn net.Conn, own string) {
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	for {
+		args, err := readRESPCommand(reader)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			continue
+		}
+
+		reply := fmt.Sprintf("-ERR unknown command '%s'\r\n", args[0])
+		switch {
+		case strings.EqualFold(args[0], "PING"):
+			reply = "+PONG\r\n"
+		case strings.EqualFold(args[0], "CLUSTER") && len(args) > 1 && strings.EqualFold(args[1], "SLOTS"):
+			reply = clusterSlotsReply(own)
+		}
+		if _, err := conn.Write([]byte(reply)); err != nil {
+			return
+		}
+	}
+}
+
+// clusterSlotsReply hands back a topology of one node owning every slot, pointing at
+// the stub itself. A cluster client will not route a command until it has one.
+func clusterSlotsReply(own string) string {
+	host, port, err := net.SplitHostPort(own)
+	if err != nil {
+		return "-ERR bad stub address\r\n"
+	}
+
+	const nodeID = "0123456789abcdef0123456789abcdef01234567"
+
+	return fmt.Sprintf("*1\r\n*3\r\n:0\r\n:16383\r\n*3\r\n$%d\r\n%s\r\n:%s\r\n$%d\r\n%s\r\n",
+		len(host), host, port, len(nodeID), nodeID)
+}
+
+func readRESPCommand(reader *bufio.Reader) ([]string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if len(line) < 2 || line[0] != '*' {
+		return nil, fmt.Errorf("expected array, got %q", line)
+	}
+
+	count, err := strconv.Atoi(line[1 : len(line)-2])
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if len(header) < 2 || header[0] != '$' {
+			return nil, fmt.Errorf("expected bulk string, got %q", header)
+		}
+
+		length, err := strconv.Atoi(header[1 : len(header)-2])
+		if err != nil {
+			return nil, err
+		}
+
+		buf := make([]byte, length+2) // payload plus trailing CRLF
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:length]))
+	}
+
+	return args, nil
+}
+
+// TestBuildRedisClientTLSHandshake exercises the whole path an encrypted
+// ElastiCache/Valkey cluster takes: a TLSConfig on the cache config has to
+// survive buildRedisClient and reach the dialer, or the handshake never happens.
+func TestBuildRedisClientTLSHandshake(t *testing.T) {
+	addr, roots := startTLSRedisStub(t)
+
+	t.Run("TLSConfig connects", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisCacheConfig{
+				Addr:        addr,
+				DialTimeout: 5 * time.Second,
+				ReadTimeout: 5 * time.Second,
+				TLSConfig:   &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
+			},
+		}, nil)
+		require.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("rediss URL connects without an explicit TLSConfig", func(t *testing.T) {
+		// The URL supplies TLS; RootCAs still has to be threaded in for the
+		// self-signed stub, but ServerName comes from the URL host.
+		opts := ToRedisOptions(&core.RedisCacheConfig{
+			Addr:        "rediss://" + addr,
+			DialTimeout: 5 * time.Second,
+			ReadTimeout: 5 * time.Second,
+		})
+		require.NotNil(t, opts.TLSConfig, "rediss scheme should imply TLS")
+		opts.TLSConfig.RootCAs = roots
+		opts.TLSConfig.ServerName = "localhost"
+
+		client := redis.NewClient(opts)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("caller-supplied client keeps its own TLS", func(t *testing.T) {
+		// The point of WithRedisClient: the SDK maps a fixed set of go-redis
+		// fields, but a client handed over whole arrives with whatever its owner
+		// configured. Nothing here is expressible through RedisCacheConfig.
+		own := redis.NewClient(&redis.Options{
+			Addr:        addr,
+			DialTimeout: 5 * time.Second,
+			ReadTimeout: 5 * time.Second,
+			TLSConfig:   &tls.Config{RootCAs: roots, ServerName: "localhost", MinVersion: tls.VersionTLS13},
+		})
+		t.Cleanup(func() { _ = own.Close() })
+
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: core.WithRedisClient(own),
+		}, nil)
+		require.Same(t, own, client, "the datastream should share the client, not rebuild it")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("cluster TLSConfig connects", func(t *testing.T) {
+		// The case this whole change exists for: an encrypted ElastiCache/Valkey
+		// cluster. Mapping the option is not proof it reaches the dialer.
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisCacheClusterConfig{
+				Addrs:       []string{addr},
+				DialTimeout: 5 * time.Second,
+				ReadTimeout: 5 * time.Second,
+				TLSConfig:   &tls.Config{RootCAs: roots, ServerName: "localhost", MinVersion: tls.VersionTLS12},
+			},
+		}, nil)
+		require.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("cluster rediss URL connects without an explicit TLSConfig", func(t *testing.T) {
+		// ParseClusterURL takes ServerName from the URL host, which is the stub's
+		// 127.0.0.1; RootCAs still has to be threaded in for the self-signed cert.
+		opts, err := toRedisClusterOptions(&core.RedisCacheClusterConfig{
+			Addrs:       []string{"rediss://" + addr},
+			DialTimeout: 5 * time.Second,
+			ReadTimeout: 5 * time.Second,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, opts.TLSConfig, "rediss scheme should imply TLS")
+		assert.Equal(t, []string{addr}, opts.Addrs, "the scheme should be stripped off the address")
+		opts.TLSConfig.RootCAs = roots
+
+		client := redis.NewClusterClient(opts)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		pong, err := client.Ping(ctx).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "PONG", pong)
+	})
+
+	t.Run("nil TLSConfig cannot talk to an encrypted server", func(t *testing.T) {
+		client := buildRedisClient(&core.DatastreamOptions{
+			CacheConfig: &core.RedisCacheConfig{
+				Addr:        addr,
+				DialTimeout: 2 * time.Second,
+				ReadTimeout: 2 * time.Second,
+				MaxRetries:  -1,
+			},
+		}, nil)
+		require.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := client.Ping(ctx).Result()
+		assert.Error(t, err, "a plaintext client should not reach a TLS-only server")
+	})
+}

--- a/datastream/client.go
+++ b/datastream/client.go
@@ -25,7 +25,7 @@ func NewDataStreamClient(options DataStreamClientOptions, configurationOptions *
 	}
 
 	// Build a shared Redis client (if configured) for all cache providers
-	redisClient := buildRedisClient(configurationOptions)
+	redisClient := buildRedisClient(configurationOptions, options.Logger)
 
 	// Get or create cache providers based on options
 	companyCacheProvider, userCacheProvider := getCacheProviders(options, configurationOptions, redisClient)

--- a/option/custom_options.go
+++ b/option/custom_options.go
@@ -17,6 +17,7 @@ var WithLogger = core.WithLogger
 var WithLogLevel = core.WithLogLevel
 var WithDatastream = core.WithDatastream
 var WithRedisCache = core.WithRedisCache
+var WithRedisClient = core.WithRedisClient
 var WithCacheTTL = core.WithCacheTTL
 var WithReplicatorMode = core.WithReplicatorMode
 var WithReplicatorHealthURL = core.WithReplicatorHealthURL
@@ -24,6 +25,7 @@ var WithReplicatorHealthInterval = core.WithReplicatorHealthInterval
 
 type RedisCacheConfig = core.RedisCacheConfig
 type RedisCacheClusterConfig = core.RedisCacheClusterConfig
+type RedisClientConfig = core.RedisClientConfig
 type LogLevel = core.LogLevel
 
 const (


### PR DESCRIPTION
Adds what schematic-api needs to turn datastream flag checks back on against the encrypted cache cluster (SchematicHQ/schematic-api#7506). Supersedes #203.

Three changes to the datastream Redis config:

**TLS.** `TLSConfig *tls.Config` on `RedisCacheConfig` and `RedisCacheClusterConfig`. Nil is go-redis' plaintext default, so existing callers are unaffected.

**Connection URLs.** The api passes `redis://host:6379` into `Addr`, where go-redis wants a bare `host:port`, so the value reaches `net.Dial` and fails unconditionally. Both configs now parse a URL — from a new `URL` field, or from a scheme-bearing address. Struct fields override what the URL derived, matching the precedence in `api/lib/redis/client.go`. A `rediss://` URL supplies its own `TLSConfig`, so TLS needs no further config.

A URL that does not parse, or that names no host, leaves the datastream on its local cache instead of being dialed. Both would otherwise reach go-redis' `localhost:6379` default — a silent, guaranteed-broken dial is what produced the 25s `/components/hydrate` stalls. The warning redacts credentials and withholds the parse error when the URL carries any; `net/url` quotes both the URL and fragments of it into its errors, so an unescaped `/` in a password comes back as an "invalid port".

**Caller-supplied clients.** `WithRedisClient(redis.UniversalClient)`, carried over from #203. The field-by-field configs map a fixed set of go-redis options, so a custom dialer, hook or tracing wrapper cannot be expressed through them. The api already builds a client in `api/lib/redis/client.go` wrapped in `redistrace.WrapClient`, so handing it over whole also gets Datadog spans without this SDK taking a dd-trace dependency.

### Testing

`cache_tls_test.go` stands up a TLS listener speaking enough RESP for a handshake, a PING and `CLUSTER SLOTS`, covering both single-instance and cluster TLS — the gap #204 had on its own, since miniredis is plaintext-only. `cache_test.go` covers the option matrix for both shapes. Every guard was mutation-checked.

Not verified: a real encrypted ElastiCache cluster, and the schematic-api side. Those wait on the soak.

Needs a tag before schematic-api can pick it up. That bump lands on v1.5.5, which carries the WASM rules-engine swap (#191), so it deserves its own soak.
